### PR TITLE
CLOUD-487: support string:string maps in go-i18n

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,19 +1,19 @@
-go-i18n [![Build Status](https://travis-ci.org/Liam-Williams/go-i18n.svg?branch=master)](http://travis-ci.org/Liam-Williams/go-i18n) [![Sourcegraph](https://sourcegraph.com/github.com/Liam-Williams/go-i18n/-/badge.svg)](https://sourcegraph.com/github.com/Liam-Williams/go-i18n?badge)
+go-i18n [![Build Status](https://travis-ci.org/EverlongProject/go-i18n.svg?branch=master)](http://travis-ci.org/EverlongProject/go-i18n) [![Sourcegraph](https://sourcegraph.com/github.com/EverlongProject/go-i18n/-/badge.svg)](https://sourcegraph.com/github.com/EverlongProject/go-i18n?badge)
 =======
 
 go-i18n is a Go [package](#i18n-package) and a [command](#goi18n-command) that helps you translate Go programs into multiple languages.
 * Supports [pluralized strings](http://cldr.unicode.org/index/cldr-spec/plural-rules) for all 200+ languages in the [Unicode Common Locale Data Repository (CLDR)](http://www.unicode.org/cldr/charts/28/supplemental/language_plural_rules.html).
-  *  Code and tests are [automatically generated](https://github.com/Liam-Williams/go-i18n/tree/master/i18n/language/codegen) from [CLDR data](http://cldr.unicode.org/index/downloads)
+  *  Code and tests are [automatically generated](https://github.com/EverlongProject/go-i18n/tree/master/i18n/language/codegen) from [CLDR data](http://cldr.unicode.org/index/downloads)
 * Supports strings with named variables using [text/template](http://golang.org/pkg/text/template/) syntax.
 * Translation files are simple JSON, TOML or YAML.
-* [Documented](http://godoc.org/github.com/Liam-Williams/go-i18n) and [tested](https://travis-ci.org/Liam-Williams/go-i18n)!
+* [Documented](http://godoc.org/github.com/EverlongProject/go-i18n) and [tested](https://travis-ci.org/EverlongProject/go-i18n)!
 
-Package i18n [![GoDoc](http://godoc.org/github.com/Liam-Williams/go-i18n?status.svg)](http://godoc.org/github.com/Liam-Williams/go-i18n/i18n)
+Package i18n [![GoDoc](http://godoc.org/github.com/EverlongProject/go-i18n?status.svg)](http://godoc.org/github.com/EverlongProject/go-i18n/i18n)
 ------------
 
 The i18n package provides runtime APIs for fetching translated strings.
 
-Command goi18n [![GoDoc](http://godoc.org/github.com/Liam-Williams/go-i18n?status.svg)](http://godoc.org/github.com/Liam-Williams/go-i18n/goi18n)
+Command goi18n [![GoDoc](http://godoc.org/github.com/EverlongProject/go-i18n?status.svg)](http://godoc.org/github.com/EverlongProject/go-i18n/goi18n)
 --------------
 
 The goi18n command provides functionality for managing the translation process.
@@ -23,7 +23,7 @@ Installation
 
 Make sure you have [setup GOPATH](http://golang.org/doc/code.html#GOPATH).
 
-    go get -u github.com/Liam-Williams/go-i18n/goi18n
+    go get -u github.com/EverlongProject/go-i18n/goi18n
     goi18n -help
 
 Workflow
@@ -116,11 +116,11 @@ Here is an example of the default file format that go-i18n supports:
 ]
 ```
 
-To use a different file format, write a parser for the format and add the parsed translations using [AddTranslation](https://godoc.org/github.com/Liam-Williams/go-i18n/i18n#AddTranslation).
+To use a different file format, write a parser for the format and add the parsed translations using [AddTranslation](https://godoc.org/github.com/EverlongProject/go-i18n/i18n#AddTranslation).
 
 Note that TOML only supports the flat format, which is described below.
 
-More examples of translation files: [JSON](https://github.com/Liam-Williams/go-i18n/tree/master/goi18n/testdata/input), [TOML](https://github.com/Liam-Williams/go-i18n/blob/master/goi18n/testdata/input/flat/ar-ar.one.toml), [YAML](https://github.com/Liam-Williams/go-i18n/blob/master/goi18n/testdata/input/yaml/en-us.one.yaml).
+More examples of translation files: [JSON](https://github.com/EverlongProject/go-i18n/tree/master/goi18n/testdata/input), [TOML](https://github.com/EverlongProject/go-i18n/blob/master/goi18n/testdata/input/flat/ar-ar.one.toml), [YAML](https://github.com/EverlongProject/go-i18n/blob/master/goi18n/testdata/input/yaml/en-us.one.yaml).
 
 Flat Format
 -------------
@@ -170,7 +170,7 @@ and name of substructures (ids) should be always a string.
 If there is only one key in substructure and it is "other", then it's non-plural
 translation, else plural.
 
-More examples of flat format translation files can be found in [goi18n/testdata/input/flat](https://github.com/Liam-Williams/go-i18n/tree/master/goi18n/testdata/input/flat).
+More examples of flat format translation files can be found in [goi18n/testdata/input/flat](https://github.com/EverlongProject/go-i18n/tree/master/goi18n/testdata/input/flat).
 
 Contributions
 -------------

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,8 @@
+module github.com/EverlongProject/go-i18n
+
+go 1.16
+
+require (
+	github.com/pelletier/go-toml v1.8.1
+	gopkg.in/yaml.v2 v2.4.0
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,8 @@
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pelletier/go-toml v1.8.1 h1:1Nf83orprkJyknT6h7zbuEGUEjcyVlCxSUGTENmNCRM=
+github.com/pelletier/go-toml v1.8.1/go.mod h1:T2/BmBdy8dvIRq1a/8aqjN41wvWlN4lrapLU/GW4pbc=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=
+gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=

--- a/goi18n/constants_command.go
+++ b/goi18n/constants_command.go
@@ -13,9 +13,9 @@ import (
 	"text/template"
 	"unicode"
 
-	"github.com/Liam-Williams/go-i18n/i18n/bundle"
-	"github.com/Liam-Williams/go-i18n/i18n/language"
-	"github.com/Liam-Williams/go-i18n/i18n/translation"
+	"github.com/EverlongProject/go-i18n/i18n/bundle"
+	"github.com/EverlongProject/go-i18n/i18n/language"
+	"github.com/EverlongProject/go-i18n/i18n/translation"
 )
 
 type constantsCommand struct {

--- a/goi18n/doc.go
+++ b/goi18n/doc.go
@@ -1,6 +1,6 @@
 // The goi18n command formats and merges translation files.
 //
-//     go get -u github.com/Liam-Williams/go-i18n/goi18n
+//     go get -u github.com/EverlongProject/go-i18n/goi18n
 //     goi18n -help
 //
 // Help documentation:

--- a/goi18n/gendoc.sh
+++ b/goi18n/gendoc.sh
@@ -1,7 +1,7 @@
 go install
 echo "// The goi18n command formats and merges translation files." > doc.go
 echo "//" >> doc.go
-echo "//     go get -u github.com/Liam-Williams/go-i18n/goi18n" >> doc.go
+echo "//     go get -u github.com/EverlongProject/go-i18n/goi18n" >> doc.go
 echo "//     goi18n -help" >> doc.go
 echo "//" >> doc.go
 echo "// Help documentation:" >> doc.go

--- a/goi18n/merge_command.go
+++ b/goi18n/merge_command.go
@@ -11,9 +11,9 @@ import (
 
 	"gopkg.in/yaml.v2"
 
-	"github.com/Liam-Williams/go-i18n/i18n/bundle"
-	"github.com/Liam-Williams/go-i18n/i18n/language"
-	"github.com/Liam-Williams/go-i18n/i18n/translation"
+	"github.com/EverlongProject/go-i18n/i18n/bundle"
+	"github.com/EverlongProject/go-i18n/i18n/language"
+	"github.com/EverlongProject/go-i18n/i18n/translation"
 	toml "github.com/pelletier/go-toml"
 )
 

--- a/goi18n/testdata/en-us.flat.json
+++ b/goi18n/testdata/en-us.flat.json
@@ -1,7 +1,5 @@
 {
-  "program_greeting": {
-    "other": "Hello world"
-  },
+  "program_greeting": "Hello world",
 
   "person_greeting": {
     "other": "Hello {{.Person}}"

--- a/i18n/bundle/bundle_test.go
+++ b/i18n/bundle/bundle_test.go
@@ -9,8 +9,8 @@ import (
 	"reflect"
 	"sort"
 
-	"github.com/Liam-Williams/go-i18n/i18n/language"
-	"github.com/Liam-Williams/go-i18n/i18n/translation"
+	"github.com/EverlongProject/go-i18n/i18n/language"
+	"github.com/EverlongProject/go-i18n/i18n/translation"
 )
 
 func TestMustLoadTranslationFile(t *testing.T) {

--- a/i18n/example_test.go
+++ b/i18n/example_test.go
@@ -3,7 +3,7 @@ package i18n_test
 import (
 	"fmt"
 
-	"github.com/Liam-Williams/go-i18n/i18n"
+	"github.com/EverlongProject/go-i18n/i18n"
 )
 
 func Example() {

--- a/i18n/exampletemplate_test.go
+++ b/i18n/exampletemplate_test.go
@@ -1,7 +1,7 @@
 package i18n_test
 
 import (
-	"github.com/Liam-Williams/go-i18n/i18n"
+	"github.com/EverlongProject/go-i18n/i18n"
 	"os"
 	"text/template"
 )

--- a/i18n/exampleyaml_test.go
+++ b/i18n/exampleyaml_test.go
@@ -2,7 +2,7 @@ package i18n_test
 
 import (
 	"fmt"
-	"github.com/Liam-Williams/go-i18n/i18n"
+	"github.com/EverlongProject/go-i18n/i18n"
 )
 
 func ExampleYAML() {

--- a/i18n/i18n.go
+++ b/i18n/i18n.go
@@ -56,9 +56,9 @@
 package i18n
 
 import (
-	"github.com/Liam-Williams/go-i18n/i18n/bundle"
-	"github.com/Liam-Williams/go-i18n/i18n/language"
-	"github.com/Liam-Williams/go-i18n/i18n/translation"
+	"github.com/EverlongProject/go-i18n/i18n/bundle"
+	"github.com/EverlongProject/go-i18n/i18n/language"
+	"github.com/EverlongProject/go-i18n/i18n/translation"
 )
 
 // TranslateFunc returns the translation of the string identified by translationID.

--- a/i18n/language/pluralspec_test.go
+++ b/i18n/language/pluralspec_test.go
@@ -70,7 +70,7 @@ func TestGetPluralSpec(t *testing.T) {
 	for _, test := range tests {
 		spec := getPluralSpec(test.src)
 		if spec != test.spec {
-			t.Errorf("getPluralSpec(%q) = %q expected %q", test.src, spec, test.spec)
+			t.Errorf("getPluralSpec(%v) = %v expected %v", test.src, spec, test.spec)
 		}
 	}
 }

--- a/i18n/translation/plural_translation.go
+++ b/i18n/translation/plural_translation.go
@@ -1,7 +1,7 @@
 package translation
 
 import (
-	"github.com/Liam-Williams/go-i18n/i18n/language"
+	"github.com/EverlongProject/go-i18n/i18n/language"
 )
 
 type pluralTranslation struct {

--- a/i18n/translation/plural_translation_test.go
+++ b/i18n/translation/plural_translation_test.go
@@ -4,7 +4,7 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/Liam-Williams/go-i18n/i18n/language"
+	"github.com/EverlongProject/go-i18n/i18n/language"
 )
 
 func mustTemplate(t *testing.T, src string) *template {

--- a/i18n/translation/single_translation.go
+++ b/i18n/translation/single_translation.go
@@ -1,7 +1,7 @@
 package translation
 
 import (
-	"github.com/Liam-Williams/go-i18n/i18n/language"
+	"github.com/EverlongProject/go-i18n/i18n/language"
 )
 
 type singleTranslation struct {

--- a/i18n/translation/translation.go
+++ b/i18n/translation/translation.go
@@ -4,7 +4,7 @@ package translation
 import (
 	"fmt"
 
-	"github.com/Liam-Williams/go-i18n/i18n/language"
+	"github.com/EverlongProject/go-i18n/i18n/language"
 )
 
 // Translation is the interface that represents a translated string.

--- a/i18n/translations_test.go
+++ b/i18n/translations_test.go
@@ -3,7 +3,7 @@ package i18n
 import (
 	"testing"
 
-	"github.com/Liam-Williams/go-i18n/i18n/bundle"
+	"github.com/EverlongProject/go-i18n/i18n/bundle"
 )
 
 var bobMap = map[string]interface{}{"Person": "Bob"}
@@ -63,7 +63,7 @@ func testFile(t *testing.T, path string) {
 
 		got := T(tc.id, args...)
 		if got != tc.want {
-			t.Error("got: %v; want: %v", got, tc.want)
+			t.Errorf("got: %v; want: %v", got, tc.want)
 		}
 	}
 }


### PR DESCRIPTION
This flat file format assumes everything is a map of strings to objects. We want to be able to support string:string, since that's the default that Localise uses if there's only one translation. We also want to be able to support string:map, to allow specifying plural rules.

Additionally, update our fork to include proper module information, and fix a couple of tests that had go vet failures.