### PR TITLE
BACK-750: fix encoding of fallback translations

### DIFF
--- a/i18n/bundle/bundle.go
+++ b/i18n/bundle/bundle.go
@@ -5,11 +5,11 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"html/template"
 	"io/ioutil"
 	"path/filepath"
 	"reflect"
 	"sync"
+	"text/template"
 	"unicode"
 
 	"github.com/EverlongProject/go-i18n/i18n/language"

--- a/i18n/bundle/bundle_test.go
+++ b/i18n/bundle/bundle_test.go
@@ -162,6 +162,22 @@ func TestTfuncAndLanguage(t *testing.T) {
 	}
 }
 
+func TestFallbackTemplateEncoding(t *testing.T) {
+	b := New()
+	translationID := "id with param: {{.param}}"
+	frenchLanguage := languageWithTag("fr-FR")
+	addFakeTranslation(t, b, frenchLanguage, "unused")
+	frenchT, _, err := b.TfuncAndLanguage("fr-FR")
+	if err != nil {
+		t.Fatal(err)
+	}
+	expected := "id with param: a & b"
+	got := frenchT(translationID, map[string]interface{}{"param": "a & b"}) // we expect the '&' to be preserved
+	if got != expected {
+		t.Errorf("translation was %s; expected %s", got, expected)
+	}
+}
+
 func TestConcurrent(t *testing.T) {
 	b := New()
 	// bootstrap bundle


### PR DESCRIPTION
We want to use the fallback behaviour instead of storing thousands of identical strings (and instead of adding English strings to the French locale files). However, the fallback behaviour of go-i18n is buggy: it uses text/template for found translations, but html/template for fallbacks. This causes different encoding behaviour!

Use text/template instead so fallback behaviour matches the normal translation behaviour.